### PR TITLE
Preserve inverted bracket rise-to-bolts when adjusting angle orientation

### DIFF
--- a/src/calculations/__tests__/bruteForceAlgorithm.test.ts
+++ b/src/calculations/__tests__/bruteForceAlgorithm.test.ts
@@ -1,5 +1,8 @@
 import { generateAllCombinations } from '../bruteForceAlgorithm/combinationGeneration';
+import { calculateDependentParameters } from '../bruteForceAlgorithm';
+import { calculateInvertedBracketHeight } from '../bracketCalculations';
 import type { DesignInputs } from '@/types/designInputs';
+import type { GeneticParameters } from '../bruteForceAlgorithm';
 
 describe('Brute Force Algorithm - Combination Generation', () => {
   const baseInputs: DesignInputs = {
@@ -213,6 +216,57 @@ describe('Brute Force Algorithm - Edge Cases', () => {
     combinations.forEach(combo => {
       expect(combo.bracket_type).toBe('Inverted');
     });
+  });
+});
+
+describe('Brute Force Algorithm - Angle orientation adjustments', () => {
+  test('preserves inverted rise to bolts after vertical leg adjustment', () => {
+    const designInputs: DesignInputs = {
+      support_level: 75,
+      cavity_width: 100,
+      slab_thickness: 225,
+      characteristic_load: 4,
+      top_critical_edge: 75,
+      bottom_critical_edge: 150,
+      notch_height: 0,
+      notch_depth: 0,
+      masonry_density: 2000,
+      masonry_height: 3,
+      masonry_thickness: 102.5,
+      fixing_position: 75,
+      use_custom_fixing_position: true
+    };
+
+    const geneticParameters: GeneticParameters = {
+      bracket_centres: 200,
+      bracket_thickness: 4,
+      angle_thickness: 6,
+      vertical_leg: 60,
+      bolt_diameter: 12,
+      bracket_type: 'Inverted',
+      angle_orientation: 'Standard',
+      horizontal_leg: 110,
+      channel_type: 'CPRO38',
+      fixing_position: 75
+    };
+
+    const baseInverted = calculateInvertedBracketHeight({
+      support_level: designInputs.support_level,
+      angle_thickness: geneticParameters.angle_thickness,
+      top_critical_edge: designInputs.top_critical_edge,
+      bottom_critical_edge: designInputs.bottom_critical_edge,
+      slab_thickness: designInputs.slab_thickness,
+      fixing_position: geneticParameters.fixing_position
+    });
+
+    const calculated = calculateDependentParameters(geneticParameters, designInputs);
+
+    expect(calculated.bracket_height).toBeCloseTo(
+      baseInverted.bracket_height + geneticParameters.vertical_leg,
+      12
+    );
+    expect(calculated.rise_to_bolts).toBeCloseTo(150, 12);
+    expect(calculated.rise_to_bolts).toBeCloseTo(baseInverted.rise_to_bolts, 12);
   });
 });
 

--- a/src/calculations/bruteForceAlgorithm/index.ts
+++ b/src/calculations/bruteForceAlgorithm/index.ts
@@ -214,22 +214,29 @@ export function calculateDependentParameters(
         (genetic.bracket_type === 'Inverted' && genetic.angle_orientation === 'Standard')
     ) {
         console.log(`  Applying vertical leg adjustment: +${genetic.vertical_leg}mm`);
+        const originalRiseToBolts = rise_to_bolts_calc;
         bracket_height_calc += genetic.vertical_leg;
-        
-        // IMPORTANT: Recalculate rise to bolts based on the new bracket height
-        // Do NOT just add the vertical leg to the rise to bolts!
-        rise_to_bolts_calc = calculateRiseToBolts({
-            bracket_height: bracket_height_calc,
-            distance_from_top_to_fixing: Y,
-            worst_case_adjustment: BRACKET_ANGLE_CONSTANTS.WORST_CASE_ADJUSTMENT,
-            bottom_critical_edge_distance: bottom_critical_edge,
-            support_level: inputs.support_level,
-            slab_thickness: inputs.slab_thickness,
-            top_critical_edge_distance: top_critical_edge,
-            fixing_position: genetic.fixing_position
-        });
-        
-        console.log(`  Recalculated rise to bolts after adjustment: ${rise_to_bolts_calc}mm`);
+
+        if (genetic.bracket_type === 'Standard') {
+            // IMPORTANT: Recalculate rise to bolts based on the new bracket height
+            // Do NOT just add the vertical leg to the rise to bolts!
+            rise_to_bolts_calc = calculateRiseToBolts({
+                bracket_height: bracket_height_calc,
+                distance_from_top_to_fixing: Y,
+                worst_case_adjustment: BRACKET_ANGLE_CONSTANTS.WORST_CASE_ADJUSTMENT,
+                bottom_critical_edge_distance: bottom_critical_edge,
+                support_level: inputs.support_level,
+                slab_thickness: inputs.slab_thickness,
+                top_critical_edge_distance: top_critical_edge,
+                fixing_position: genetic.fixing_position
+            });
+
+            console.log(`  Recalculated rise to bolts after adjustment: ${rise_to_bolts_calc}mm`);
+        } else {
+            // Inverted brackets keep their original rise-to-bolts geometry
+            rise_to_bolts_calc = originalRiseToBolts;
+            console.log(`  Preserved inverted rise to bolts after adjustment: ${rise_to_bolts_calc}mm`);
+        }
     }
 
     console.log(`  Final Calculated Bracket Height: ${bracket_height_calc}mm`);


### PR DESCRIPTION
## Summary
- prevent inverted brackets from recalculating rise-to-bolts when applying vertical leg adjustments so bottom geometry is preserved
- add a regression test covering inverted bracket orientation adjustments and verifying rise-to-bolts remains at 150mm

## Testing
- npm test -- --runTestsByPath src/calculations/__tests__/bruteForceAlgorithm.test.ts -t "preserves inverted rise to bolts"


------
https://chatgpt.com/codex/tasks/task_b_68da606f56b48330b63f173c732a681c